### PR TITLE
Change pfsub notation associativity

### DIFF
--- a/theories/theory.v
+++ b/theories/theory.v
@@ -92,7 +92,7 @@ Tactic Notation "vantisym" constr(v1) constr(v2) "by" tactic(T) :=
 Definition pfsub {A B:Type} (f g: A -> option B) : Prop :=
   forall x y, f x = Some y -> g x = Some y.
 
-Notation "f ⊆ g" := (pfsub f g) (at level 70, right associativity).
+Notation "f ⊆ g" := (pfsub f g) (at level 70).
 
 Theorem pfsub_refl {A B}: forall (f:A->option B), f ⊆ f.
 Proof. unfold pfsub. intros. assumption. Qed.


### PR DESCRIPTION
This notation conflicts with [a notation in the stdpp library](https://plv.mpi-sws.org/coqdoc/stdpp/stdpp.base.html#7472ec14e3f8670903ae6b55a0e2f38c), which prevents importing both Picinae and stdpp into the same file.

Associativity shouldn't matter for this notation anyways, since you can't chain `pfsub` together.

Everything still builds fine with this change.